### PR TITLE
Add missing unit for delay header

### DIFF
--- a/pkg/client/client.ts
+++ b/pkg/client/client.ts
@@ -210,7 +210,7 @@ export class Client {
     const headers = new Headers(req.headers);
 
     if (req.delay) {
-      headers.set("Upstash-Delay", req.delay.toFixed());
+      headers.set("Upstash-Delay", `${req.delay.toFixed()}s`);
     }
 
     if (req.notBefore) {


### PR DESCRIPTION
This is a bug fix for :
```
{"error":"invalid Upstash-Delay header: time: missing unit in duration \"1\""}
```

According to [documentaton](https://docs.upstash.com/qstash/features/delay#relative-delay), we need to send `"Upstash-Delay: 1s"`, I just added the missing unit in the header.
