### PR TITLE
fix: pin lib.dom.d.ts import to specific version

### DIFF
--- a/pkg/client/client.ts
+++ b/pkg/client/client.ts
@@ -8,7 +8,7 @@ import type { Log } from "./types.ts";
 import type {
   BodyInit,
   HeadersInit,
-} from "https://raw.githubusercontent.com/microsoft/TypeScript/main/lib/lib.dom.d.ts";
+} from "https://raw.githubusercontent.com/microsoft/TypeScript/7b764164ede080afff02ec731dfea72b3f4f73f3/lib/lib.dom.d.ts";
 
 export type ClientConfig = {
   /**

--- a/pkg/client/http.ts
+++ b/pkg/client/http.ts
@@ -2,7 +2,7 @@ import { QstashError } from "./error.ts";
 import type {
   BodyInit,
   HeadersInit,
-} from "https://raw.githubusercontent.com/microsoft/TypeScript/main/lib/lib.dom.d.ts";
+} from "https://raw.githubusercontent.com/microsoft/TypeScript/7b764164ede080afff02ec731dfea72b3f4f73f3/lib/lib.dom.d.ts";
 
 export type UpstashRequest = {
   /**


### PR DESCRIPTION
The lib.dom.d.ts file does not exist at `https://raw.githubusercontent.com/microsoft/TypeScript/lib/lib.dom.d.ts` anymore. So I pinned it to the commit at the time that the import was commited.