### PR TITLE
export `Nextjs` directly from `@upstash/qstash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,6 @@ It is 100% built on stateless HTTP requests and designed for:
 - WebAssembly
 - and other environments where HTTP is preferred over TCP.
 
-## Status of the SDK
-
-It is currently in beta and we are actively collecting feedback from the
-community. Please report any issues you encounter or feature requests in the
-[GitHub issues](https://github.com/upstash/sdk-qstash-ts/issues) or talk to us
-on [Discord](https://discord.gg/w9SenAtbme). Thank you!
-
 ## How does QStash work?
 
 QStash is the message broker between your serverless apps. You send an HTTP
@@ -40,12 +33,6 @@ the message later, to guarentee at-least-once delivery.
 
 ```bash
 npm install @upstash/qstash
-```
-
-#### Deno
-
-```ts
-import { Client } from "https://deno.land/x/upstash_qstash/mod.ts";
 ```
 
 ### Get your authorization token

--- a/examples/nextjs/app/edge/route.ts
+++ b/examples/nextjs/app/edge/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { verifySignatureEdge } from "@upstash/qstash/nextjs";
+import { Nextjs } from "@upstash/qstash";
 
 async function handler(_req: NextRequest) {
   // simulate work
@@ -9,6 +9,6 @@ async function handler(_req: NextRequest) {
   return NextResponse.json({ name: "John Doe" });
 }
 
-export const POST = verifySignatureEdge(handler);
+export const POST = Nextjs.verifySignatureEdge(handler);
 
 export const runtime = "edge";

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@upstash/qstash": "2.0.0-canary.21",
+    "@upstash/qstash": "2.1.1-canary.4",
     "next": "^13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/examples/nextjs/pages/api/edge.ts
+++ b/examples/nextjs/pages/api/edge.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { verifySignatureEdge } from "@upstash/qstash/nextjs";
+import { Nextjs } from "@upstash/qstash";
 
 async function handler(req: NextRequest) {
   console.log(req.headers);
@@ -11,7 +11,7 @@ async function handler(req: NextRequest) {
   return NextResponse.json({ name: "John Doe", body: req.body });
 }
 
-export default verifySignatureEdge(handler);
+export default Nextjs.verifySignatureEdge(handler);
 
 export const config = {
   runtime: "edge",

--- a/examples/nextjs/pages/api/serverless.ts
+++ b/examples/nextjs/pages/api/serverless.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { verifySignature } from "@upstash/qstash/nextjs";
+import { Nextjs } from "@upstash/qstash";
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   console.log(req.headers);
@@ -11,7 +11,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   res.status(200).json({ name: "John Doe", body: req.body });
 }
 
-export default verifySignature(handler);
+export default Nextjs.verifySignature(handler);
 
 export const config = {
   api: {

--- a/examples/nextjs/pnpm-lock.yaml
+++ b/examples/nextjs/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@upstash/qstash':
-    specifier: 2.0.0-canary.21
-    version: 2.0.0-canary.21
+    specifier: 2.1.1-canary.4
+    version: 2.1.1-canary.4
   next:
     specifier: ^13.4.19
     version: 13.4.19(react-dom@18.2.0)(react@18.2.0)
@@ -337,8 +337,8 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@upstash/qstash@2.0.0-canary.21:
-    resolution: {integrity: sha512-/iA6p308KILgkC6VVjZnCP+VfsYoVaz3+L/uvU8uxtw1+IBlp5vI0p7Rf4373ptIcFjEj9wb5vsYxR5L2a1jaA==}
+  /@upstash/qstash@2.1.1-canary.4:
+    resolution: {integrity: sha512-NWPeAgJK+SXGMCxadfsk3Ot0heop0EowUhiQ8xI1BPHyuSUcTnbn41VVhHkHcQ/Q+8mFyGb+9CV3GKTwMQtM/A==}
     dependencies:
       crypto-js: 4.1.1
       jose: 4.14.4

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@upstash/qstash",
-  "version": "2.0.0-canary.21",
+  "version": "2.1.1-canary.9",
   "description": "Official Typescript client for QStash",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/upstash/sdk-qstash-ts.git"
   },
-  "module": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "keywords": [
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/upstash/sdk-qstash-ts#readme",
   "files": [
-    "dist"
+    "./dist"
   ],
   "scripts": {
     "build": "tsup",
@@ -40,11 +40,5 @@
   "dependencies": {
     "crypto-js": "^4.1.1",
     "jose": "^4.14.4"
-  },
-  "typesVersions": {
-    "*": {
-      ".": ["./dist/index.d.ts"],
-      "nextjs": ["./dist/nextjs.d.ts"]
-    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from "./client/messages";
 export * from "./client/schedules";
 export * from "./client/topics";
 export * from "./client/types";
+export * as Nextjs from "./nextjs";

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "./src/index.ts", nextjs: "./src/nextjs.ts" },
+  entry: ["./src/index.ts"],
   format: ["cjs", "esm"],
   splitting: true,
   sourcemap: true,


### PR DESCRIPTION
The sub path modules just didn't work, I tried a few different ways, but
no success.

The new way will be:
```ts
import { Nextjs } from "@upstash/qstash"

export default Nextjs.verifySignature(handler)

```
