### PR TITLE
fix: update schedules.ts to include destination and cron on create

### DIFF
--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -95,7 +95,7 @@ export class Schedules {
       method: "POST",
       headers: { "Content-Type": "application/json", "Upstash-Cron": req.cron },
       path: ["v2", "schedules", req.destination],
-      body: JSON.stringify(req),
+      body: JSON.stringify(req.body),
     });
   }
 

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -73,7 +73,7 @@ export type CreateScheduleRequest = {
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
   /**
-   * Optionally specify a cron expression to repeatedly send this message to the destination.
+   * Specify a cron expression to repeatedly send this message to the destination.
    *
    * @default undefined
    */
@@ -91,11 +91,32 @@ export class Schedules {
    * Create a schedule
    */
   public async create(req: CreateScheduleRequest): Promise<{ scheduleId: string }> {
+    const headers = new Headers(req.headers);
+    
+    if (!headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+
+    headers.set("Upstash-Cron", req.cron)
+    headers.set("Upstash-Method", req.method ?? "POST");
+
+    if (typeof req.delay !== "undefined") {
+      headers.set("Upstash-Delay", `${req.delay.toFixed()}s`);
+    }
+
+    if (typeof req.retries !== "undefined") {
+      headers.set("Upstash-Retries", req.retries.toFixed());
+    }
+
+    if (typeof req.callback !== "undefined") {
+      headers.set("Upstash-Callback", req.callback);
+    }
+
     return await this.http.request({
       method: "POST",
-      headers: { "Content-Type": "application/json", "Upstash-Cron": req.cron },
+      headers,
       path: ["v2", "schedules", req.destination],
-      body: JSON.stringify(req.body),
+      body: req.body,
     });
   }
 

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -93,8 +93,8 @@ export class Schedules {
   public async create(req: CreateScheduleRequest): Promise<{ scheduleId: string }> {
     return await this.http.request({
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      path: ["v2", "schedules"],
+      headers: { "Content-Type": "application/json", "Upstash-Cron": req.cron },
+      path: ["v2", "schedules", req.destination],
       body: JSON.stringify(req),
     });
   }


### PR DESCRIPTION
## Description
Creating schedules using the new V2 endpoints doesn't use the destination or cron inputs and errors out with either:

`Error creating schedule: QstashError: {"error":"invalid destination url: endpoint has invalid scheme, add http:// or https://"}`
or
`Error creating schedule: QstashError: {"error":"Invalid cron expression empty spec string"}`

## Changes

- add `"Upstash-Cron": req.cron` to headers
- add `req.destination` to path


## Fixes #49 

## Updates since initial PR

- modify body property to only include `req.body`
- handle optional schedule properties

Note: This is my first PR so please don't hesitate to tell me I'm doing something wrong and happy to just wait for a general fix in the future.