### PR TITLE
Add failure callback to message, publish request, schedules

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,9 +1,9 @@
+import { DLQ } from "./dlq";
 import { HttpClient, Requester, RetryConfig } from "./http";
-import { Topics } from "./topics";
 import { Messages } from "./messages";
 import { Schedules } from "./schedules";
+import { Topics } from "./topics";
 import { Event } from "./types";
-import { DLQ } from "./dlq";
 type ClientConfig = {
   /**
    * Url of the qstash api server.
@@ -112,6 +112,15 @@ export type PublishRequest<TBody = BodyInit> = {
    * @default undefined
    */
   callback?: string;
+
+  /**
+   * Use a failure callback url to handle messages that could not be delivered.
+   *
+   * The failure callback url must be publicly accessible
+   *
+   * @default undefined
+   */
+  failureCallback?: string;
 
   /**
    * The method to use when sending a request to your API
@@ -228,6 +237,10 @@ export class Client {
 
     if (typeof req.callback !== "undefined") {
       headers.set("Upstash-Callback", req.callback);
+    }
+
+    if (typeof req.failureCallback !== "undefined") {
+      headers.set("Upstash-Failure-Callback", req.failureCallback);
     }
 
     const res = await this.http.request<PublishResponse<TRequest>>({

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -42,7 +42,7 @@ export type Message = {
   notBefore?: number;
 
   /**
-   * A unix timestamp (milliseconds) when this messages was crated.
+   * A unix timestamp (milliseconds) when this messages was created.
    */
   createdAt: number;
 

--- a/src/client/messages.ts
+++ b/src/client/messages.ts
@@ -50,6 +50,11 @@ export type Message = {
    * The callback url if configured.
    */
   callback?: string;
+
+  /**
+   * The failure callback url if configured.
+   */
+  failureCallback?: string;
 };
 
 export class Messages {

--- a/src/client/schedules.ts
+++ b/src/client/schedules.ts
@@ -11,6 +11,7 @@ export type Schedule = {
   retries: number;
   delay?: number;
   callback?: string;
+  failureCallback?: string;
 };
 
 export type CreateScheduleRequest = {
@@ -47,7 +48,7 @@ export type CreateScheduleRequest = {
   delay?: number;
 
   /**
-   * In case your destination server is unavaialble or returns a status code outside of the 200-299
+   * In case your destination server is unavailable or returns a status code outside of the 200-299
    * range, we will retry the request after a certain amount of time.
    *
    * Configure how many times you would like the delivery to be retried
@@ -64,6 +65,15 @@ export type CreateScheduleRequest = {
    * @default undefined
    */
   callback?: string;
+
+  /**
+   * Use a failure callback url to handle messages that could not be delivered.
+   *
+   * The failure callback url must be publicly accessible
+   *
+   * @default undefined
+   */
+  failureCallback?: string;
 
   /**
    * The method to use when sending a request to your API
@@ -111,6 +121,10 @@ export class Schedules {
 
     if (typeof req.callback !== "undefined") {
       headers.set("Upstash-Callback", req.callback);
+    }
+
+    if (typeof req.failureCallback !== "undefined") {
+      headers.set("Upstash-Failure-Callback", req.failureCallback);
     }
 
     return await this.http.request({


### PR DESCRIPTION
Issue #68 

- Add failure callback option to Message
- Add failure callback to PublishRequest 
- Add failure callback header in Client publish

