### PR TITLE
Event filter

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -366,6 +366,9 @@ export class Client {
     const query: Record<string, string> = {};
     Object.keys(req ?? {}).forEach(key => {
       const value = (req as Record<string, any>)[key];
+      if (typeof value === "number" && value < 0) {
+        return;
+      }
       if (typeof value !== "undefined") {
         query[key] = value.toString();
       }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -372,14 +372,14 @@ export class Client {
       query.cursor = req.cursor.toString();
     }
 
-    Object.entries(req?.filter ?? {}).forEach(([key, value]) => {
+    for (const [key, value] of Object.entries(req?.filter ?? {})) {
       if (typeof value === "number" && value < 0) {
-        return;
+        continue;
       }
       if (typeof value !== "undefined") {
         query[key] = value.toString();
       }
-    });
+    }
 
     const res = await this.http.request<GetEventsResponse>({
       path: ["v2", "events"],

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -365,7 +365,7 @@ export class Client {
   public async events(req?: EventsRequest): Promise<GetEventsResponse> {
     const query: Record<string, string> = {};
     Object.keys(req ?? {}).forEach(key => {
-      const value = (req as Record<string, any>)[key];
+      const value = (req as Record<string, string | number>)[key];
       if (typeof value === "number" && value < 0) {
         return;
       }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -157,6 +157,10 @@ export type PublishJsonRequest = Omit<PublishRequest, "body"> & {
 
 export type EventsRequest = {
   cursor?: number;
+  filter?: EventsRequestFilter
+};
+
+type EventsRequestFilter = {
   messageId?: string;
   state?: State;
   url?: string;
@@ -166,7 +170,7 @@ export type EventsRequest = {
   fromDate?: number; // unix timestamp (ms)
   toDate?: number; // unix timestamp (ms)
   count?: number;
-};
+}
 
 export type GetEventsResponse = {
   cursor?: number;
@@ -364,8 +368,11 @@ export class Client {
    */
   public async events(req?: EventsRequest): Promise<GetEventsResponse> {
     const query: Record<string, string> = {};
-    Object.keys(req ?? {}).forEach(key => {
-      const value = (req as Record<string, string | number>)[key];
+    if (req?.cursor && req.cursor > 0) {
+      query.cursor = req.cursor.toString();
+    }
+
+    Object.entries(req?.filter ?? {}).forEach(([key, value]) => {
       if (typeof value === "number" && value < 0) {
         return;
       }


### PR DESCRIPTION
Add support for filtering events by the following fields:

```
messageId: string;
state: State;
url: string;
topicName: string;
scheduleId: string;
queueName: string;
fromDate: number; // unix timestamp (ms)
toDate: number; // unix timestamp (ms)
```

Also introduce a `count` argument for better pagination.